### PR TITLE
[fix] tsconfig alias 경고 수정

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "files": [],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,14 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import tailwindcss from "@tailwindcss/vite";
-import path from "path";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss({ config: "./tailwind.config.cjs" })],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
 });


### PR DESCRIPTION
## 개요 💡
vite.config.ts 파일에서 tailwindcss()로 인해 인수 오류가 나 해당부분을 삭제했습니다.
tsconfig.json의 경로 alias 설정에서 src/* 앞에 ./이 누락되어 경고가 발생하던 문제를 수정했습니다.

## Issue 
- tsconfig.json 경로 alias 경고 발생
- pnpm dev 실행 시 tsconfig 경고
